### PR TITLE
Add ID client

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,7 +21,8 @@ func (c *Client) SupportID() (bool, error) {
 	return c.c.Support(Capability)
 }
 
-func (c *Client) id(clientID ID) (serverID ID, err error) {
+// ID sends an ID command to the server and returns the server's ID.
+func (c *Client) ID(clientID ID) (serverID ID, err error) {
 	if state := c.c.State(); imap.ConnectedState&state != state {
 		return nil, errors.New("Not connected")
 	}
@@ -40,9 +41,4 @@ func (c *Client) id(clientID ID) (serverID ID, err error) {
 	serverID = res.ID
 
 	return
-}
-
-// ID sends an ID string to the server and returns the server's ID.
-func (c *Client) ID(clientID ID) (serverID ID, err error) {
-	return c.id(clientID)
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,48 @@
+package id
+
+import (
+	"errors"
+	"github.com/emersion/go-imap"
+	"github.com/emersion/go-imap/client"
+)
+
+// Client is an ID client.
+type Client struct {
+	c *client.Client
+}
+
+// NewClient creates a new client.
+func NewClient(c *client.Client) *Client {
+	return &Client{c: c}
+}
+
+// SupportID checks if the server supports the ID extension.
+func (c *Client) SupportID() (bool, error) {
+	return c.c.Support(Capability)
+}
+
+func (c *Client) id(clientID ID) (serverID ID, err error) {
+	if state := c.c.State(); imap.ConnectedState&state != state {
+		return nil, errors.New("Not connected")
+	}
+
+	var cmd imap.Commander = &Command{ID: clientID}
+
+	res := &Response{}
+	status, err := c.c.Execute(cmd, res)
+	if err != nil {
+		return
+	}
+	if err = status.Err(); err != nil {
+		return
+	}
+
+	serverID = res.ID
+
+	return
+}
+
+// ID sends an ID string to the server and returns the server's ID.
+func (c *Client) ID(clientID ID) (serverID ID, err error) {
+	return c.id(clientID)
+}

--- a/response.go
+++ b/response.go
@@ -2,12 +2,24 @@ package id
 
 import (
 	"github.com/emersion/go-imap"
+	"github.com/emersion/go-imap/responses"
 )
 
 // An ID response.
 // See RFC 2971 section 3.2.
 type Response struct {
 	ID ID
+}
+
+func (r *Response) Handle(resp imap.Resp) (err error) {
+	name, fields, ok := imap.ParseNamedResp(resp)
+	if !ok || name != responseName {
+		return responses.ErrUnhandled
+	}
+
+	r.ID, err = parseID(fields)
+
+	return
 }
 
 func (r *Response) Parse(fields []interface{}) (err error) {


### PR DESCRIPTION
This PR adds support for clients.

Clients can use the function `SupportID()` to determine if the server supports the ID command.
In addition, they can send an ID command and get the server's ID as response.

I hope this meets all requirements to get merged.

Thanks.