### PR TITLE
Fix bug with thunderbird.  Don't quote ID in response.

### DIFF
--- a/response.go
+++ b/response.go
@@ -28,7 +28,7 @@ func (r *Response) Parse(fields []interface{}) (err error) {
 }
 
 func (r *Response) WriteTo(w *imap.Writer) error {
-	fields := []interface{}{responseName, formatID(r.ID)}
+	fields := []interface{}{imap.RawString(responseName), formatID(r.ID)}
 
 	res := imap.NewUntaggedResp(fields)
 	return res.WriteTo(w)


### PR DESCRIPTION
Thunderbird fails to parse the ID response if ID is quoted and closes the connection.